### PR TITLE
Update mostlyportable-gcc.sh

### DIFF
--- a/mostlyportable-gcc.sh
+++ b/mostlyportable-gcc.sh
@@ -620,7 +620,7 @@ _nowhere="$PWD"
       ${_nowhere}/build/gcc/configure \
         --with-pkgversion='TkG-mostlyportable' \
         --disable-bootstrap \
-        --enable-languages=c,c++,lto \
+        ${_gcc_lang_args} \
         --with-gcc-major-version-only \
         --enable-linker-build-id \
         --disable-libstdcxx-pch \


### PR DESCRIPTION
Changed --enable-languages=c,c++,lto to ${_gcc_lang_args} for config file to work as fortran and ada arguments were not working.

Shouldn't this also be applied for  _mingw_lang_args ?