### PR TITLE
MingW GCC-11 using gcc-11 fix

### DIFF
--- a/mostlyportable-mingw.cfg
+++ b/mostlyportable-mingw.cfg
@@ -13,7 +13,7 @@ _use_gcc_git="true"
 
 # If _use_gcc_git="false", set to desired release version (example: "9.3.0")
 # If _use_gcc_git="true", set to tag, commit, branch or empty (to use latest master)
-_gcc_version="releases/gcc-10"
+_gcc_version="releases/gcc-11"
 
 # git repo to use to source gcc when _use_gcc_git="true" - default is https://github.com/gcc-mirror/gcc.git for speed - main repo is https://gcc.gnu.org/git/gcc.git
 _gcc_git="https://github.com/gcc-mirror/gcc.git"
@@ -24,7 +24,7 @@ _use_mingw_git="false"
 
 # If _use_mingw_git="false", set to desired release version (example: "7.0.0")
 # If _use_mingw_git="true", set to tag, commit, branch or empty (to use latest master)
-_mingw=8.0.0
+_mingw=8.0.2
 
 # git repo to use to source gcc when _use_mingw_git="true" - default is https://git.code.sf.net/p/mingw-w64/mingw-w64
 _mingw_git="https://git.code.sf.net/p/mingw-w64/mingw-w64"
@@ -62,6 +62,7 @@ _osl=0.9.2
 _cloog=0.20.0
 
 # Tools version vars before version bump if anyone wants to fallback
+#_mingw=8.0.0
 #_binutils=2.35
 #_gmp=6.2.0
 #_mpfr=4.1.0


### PR DESCRIPTION
gcc version bump to 11
migw tarball version bump to 8.0.2

Successfully built
gcc-mostlyportable-11.1.1-releases-gcc.11.1.0.r80.ga6b45a8d16b
and
mingw-mostlyportable-11.1.1-releases-gcc.11.1.0.r80.ga6b45a8d16b
under Ubuntu 20.04 (Focal)
:)