### PR TITLE
correct path to the lto link

### DIFF
--- a/mostlyportable-gcc.sh
+++ b/mostlyportable-gcc.sh
@@ -624,7 +624,7 @@ _nowhere="$PWD"
       rm -f "${_dstdir}"/usr/lib/libcc1.*
       # create lto plugin link
       mkdir -p "${_dstdir}"/usr/lib/bfd-plugins
-      ln -sf "../gcc/x86_64-w64-mingw32/${_gcc_version}/liblto_plugin.so" "${_dstdir}"/usr/lib/bfd-plugins/liblto_plugin.so
+      ln -sf "../libexec/gcc/x86_64-w64-mingw32/${_gcc_version}/liblto_plugin.so" "${_dstdir}"/usr/lib/bfd-plugins/liblto_plugin.so
       ln -s "./usr/bin" "${_dstdir}"/
       ln -s "./usr/lib" "${_dstdir}"/
       # Ninja hack for Arch - Just leaving this here in case we have some ninja case for MinGW

--- a/mostlyportable-gcc.sh
+++ b/mostlyportable-gcc.sh
@@ -624,7 +624,7 @@ _nowhere="$PWD"
       rm -f "${_dstdir}"/usr/lib/libcc1.*
       # create lto plugin link
       mkdir -p "${_dstdir}"/usr/lib/bfd-plugins
-      ln -sf "../libexec/gcc/x86_64-w64-mingw32/${_gcc_version}/liblto_plugin.so" "${_dstdir}"/usr/lib/bfd-plugins/liblto_plugin.so
+      ln -sf "../../libexec/gcc/x86_64-w64-mingw32/${_gcc_version}/liblto_plugin.so" "${_dstdir}"/usr/lib/bfd-plugins/liblto_plugin.so
       ln -s "./usr/bin" "${_dstdir}"/
       ln -s "./usr/lib" "${_dstdir}"/
       # Ninja hack for Arch - Just leaving this here in case we have some ninja case for MinGW


### PR DESCRIPTION

Because it is passing,
--libexecdir="${_dstdir}/usr/lib" \

liblto_plugin.so.0.0.0 is here now:
mostlyportable-gcc/mingw-mostlyportable-10.3.0/libexec/gcc/x86_64-w64-mingw32/10.3.0/liblto_plugin.so.0.0.0

Causing the broken symbolic link:
![Link LTO](https://user-images.githubusercontent.com/57958460/173213486-7def992b-c429-4de1-85fc-2dcc6aa6544a.png)